### PR TITLE
removes default 1column layout

### DIFF
--- a/M2 layout.xml.xml
+++ b/M2 layout.xml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page #if(${Page_Layout} != "") layout="${Page_Layout}" #else layout="1column" #end xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page #if(${Page_Layout} != "") layout="${Page_Layout}" #end xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
     
     </body>


### PR DESCRIPTION
you can specify it in the dialog, if needed - otherwise (most cases) you don't need a page_layout ID